### PR TITLE
Change default state for categories to null

### DIFF
--- a/src/Components/Dashboard/Dashboard.js
+++ b/src/Components/Dashboard/Dashboard.js
@@ -117,6 +117,7 @@ const Dashboard = ({ city }) => {
             changeCategory(e);
             clearSelected();
             setPopularSelected(true);
+            setCategories(null);
           }}
         >
           Popular

--- a/src/Components/Dashboard/Dashboard.js
+++ b/src/Components/Dashboard/Dashboard.js
@@ -6,7 +6,7 @@ import NavBar from "../NavBar/NavBar";
 import { FETCH_PLACES } from "../Queries";
 
 const Dashboard = ({ city }) => {
-  const [categories, setCategories] = useState(["tourism.attraction"]);
+  const [categories, setCategories] = useState(null);
   const [restaurantSelected, setRestaurantSelected] = useState(false);
   const [entertainmentSelected, setEntertainmentSelected] = useState(false);
   const [historySelected, setHistorySelected] = useState(false);


### PR DESCRIPTION
This branch will set default state for categories to `null` instead of `[tourism.attractions]` so that actual tourist attractions come up first instead of artwork. In addition, this will reset state for categories to null when user clicks popular filter manually.